### PR TITLE
make libraries Native AOT compatible, with ILC verification probe and…

### DIFF
--- a/.github/workflows/aot-compatibility.yml
+++ b/.github/workflows/aot-compatibility.yml
@@ -1,0 +1,40 @@
+name: Native AOT compatibility
+
+# Also invoked as a reusable workflow by the deploy workflows, which block on its result.
+# Push to dev is not listed here because the MyGet deploy workflow already runs it on that branch.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+jobs:
+  verify-aot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      # Publishing with PublishAot runs the ILC compiler over the whole library surface (all the
+      # EthernaAuthentication libraries are rooted in the probe). The project sets
+      # TreatWarningsAsErrors, so any trim/AOT warning (IL2026, IL3050, IL2075, …) fails this step.
+      - name: Verify AOT compatibility (publish)
+        run: dotnet publish test/EthernaAuthentication.AotCompatibility/EthernaAuthentication.AotCompatibility.csproj -c Release -r linux-x64
+
+      # Run the native binary so AOT issues that only surface at runtime also fail CI.
+      - name: Run AOT smoke test
+        run: ./test/EthernaAuthentication.AotCompatibility/bin/Release/net10.0/linux-x64/publish/EthernaAuthentication.AotCompatibility

--- a/.github/workflows/myget-unstable-deploy.yml
+++ b/.github/workflows/myget-unstable-deploy.yml
@@ -7,7 +7,11 @@ on:
     - 'release/**'
 
 jobs:
+  verify-aot:
+    uses: ./.github/workflows/aot-compatibility.yml
+
   build-test-package:
+    needs: verify-aot
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nuget-stable-deploy.yml
+++ b/.github/workflows/nuget-stable-deploy.yml
@@ -6,7 +6,11 @@ on:
       - 'v*.*.*'
 
 jobs:
+  verify-aot:
+    uses: ./.github/workflows/aot-compatibility.yml
+
   build-test-package:
+    needs: verify-aot
     runs-on: ubuntu-latest
 
     steps:

--- a/EthernaAuthentication.sln
+++ b/EthernaAuthentication.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EthernaAuthentication.UnitT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EthernaAuthentication.AspNetCore.UnitTest", "test\EthernaAuthentication.AspNetCore.UnitTest\EthernaAuthentication.AspNetCore.UnitTest.csproj", "{EFB75739-73B2-412B-81B0-9454A5AF46AE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EthernaAuthentication.AotCompatibility", "test\EthernaAuthentication.AotCompatibility\EthernaAuthentication.AotCompatibility.csproj", "{753809F6-F5B1-4C68-9202-7E2A5E1B0959}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +117,18 @@ Global
 		{EFB75739-73B2-412B-81B0-9454A5AF46AE}.Release|x64.Build.0 = Release|Any CPU
 		{EFB75739-73B2-412B-81B0-9454A5AF46AE}.Release|x86.ActiveCfg = Release|Any CPU
 		{EFB75739-73B2-412B-81B0-9454A5AF46AE}.Release|x86.Build.0 = Release|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Debug|x64.Build.0 = Debug|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Debug|x86.Build.0 = Debug|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Release|Any CPU.Build.0 = Release|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Release|x64.ActiveCfg = Release|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Release|x64.Build.0 = Release|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Release|x86.ActiveCfg = Release|Any CPU
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -127,6 +141,7 @@ Global
 		{B4131406-A4F8-4205-906D-F8B9B393388F} = {712F092A-F6AE-4A7F-B65F-B5B0ADC9849D}
 		{0F03E6A8-2E41-426F-8402-E676A972DDDF} = {CFC86E59-1F61-4FFD-87FD-F5CDD1C8CE83}
 		{EFB75739-73B2-412B-81B0-9454A5AF46AE} = {CFC86E59-1F61-4FFD-87FD-F5CDD1C8CE83}
+		{753809F6-F5B1-4C68-9202-7E2A5E1B0959} = {CFC86E59-1F61-4FFD-87FD-F5CDD1C8CE83}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BE970C17-E6A2-4FB9-8CF6-9BC80F2CAA4E}

--- a/src/EthernaAuthentication.Native/CodeFlow/EthernaCodeSignInService.cs
+++ b/src/EthernaAuthentication.Native/CodeFlow/EthernaCodeSignInService.cs
@@ -14,7 +14,7 @@
 
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OpenIdConnect;
-using IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
 using System;

--- a/src/EthernaAuthentication.Native/CodeFlow/SystemBrowser.cs
+++ b/src/EthernaAuthentication.Native/CodeFlow/SystemBrowser.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 using System;
 using System.Diagnostics;
 using System.Net;

--- a/src/EthernaAuthentication.Native/EthernaAuthentication.Native.csproj
+++ b/src/EthernaAuthentication.Native/EthernaAuthentication.Native.csproj
@@ -28,11 +28,13 @@
 
   <ItemGroup>
     <PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" Version="4.2.0" />
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="6.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
+    <!-- Direct reference (AddHybridCache is called directly), lifting the transitive Duende version. -->
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EthernaAuthentication.Native/PasswordFlow/EthernaApiKeySignInService.cs
+++ b/src/EthernaAuthentication.Native/PasswordFlow/EthernaApiKeySignInService.cs
@@ -14,8 +14,8 @@
 
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OpenIdConnect;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
 using System;

--- a/src/EthernaAuthentication/DiscoveryDocumentService.cs
+++ b/src/EthernaAuthentication/DiscoveryDocumentService.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/src/EthernaAuthentication/EthernaAuthentication.csproj
+++ b/src/EthernaAuthentication/EthernaAuthentication.csproj
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IdentityModel" Version="7.0.0" />
+    <PackageReference Include="Duende.IdentityModel" Version="8.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EthernaAuthentication/EthernaClaimTypes.cs
+++ b/src/EthernaAuthentication/EthernaClaimTypes.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Security.Claims;
 
 namespace Etherna.Authentication

--- a/src/EthernaAuthentication/EthernaOpenIdConnectClientBase.cs
+++ b/src/EthernaAuthentication/EthernaOpenIdConnectClientBase.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/EthernaAuthentication/IDiscoveryDocumentService.cs
+++ b/src/EthernaAuthentication/IDiscoveryDocumentService.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using System.Threading.Tasks;
 
 namespace Etherna.Authentication

--- a/test/EthernaAuthentication.AotCompatibility/EthernaAuthentication.AotCompatibility.csproj
+++ b/test/EthernaAuthentication.AotCompatibility/EthernaAuthentication.AotCompatibility.csproj
@@ -1,0 +1,65 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Native AOT compatibility probe for the EthernaAuthentication libraries.
+
+    Publishing this app with `dotnet publish -r <rid> -c Release` runs the ILC compiler, which
+    (unlike the Roslyn trim/AOT analyzers) does NOT skip [GeneratedCode] code. It therefore gives
+    a realistic, honest report of every trim/AOT warning across the libraries' surface.
+
+    All the libraries are added as TrimmerRootAssembly so ILC analyzes every operation
+    (not just what Main happens to reach). Dependencies (Duende, IdentityModel, ASP.NET Core) are
+    left to normal trimming, so only the code paths actually used are analyzed.
+
+    Any IL2026/IL3050/etc. warning fails the publish (warnings-as-errors).
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Etherna.Authentication.AotCompatibility</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>true</IsPublishable>
+
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+
+    <!-- Warnings from the exempted assemblies below collapse into IL2104/IL3053: with
+         TrimmerSingleWarn=false no other assembly can produce these codes, so suppressing
+         them keeps the detailed warnings-as-errors gate intact everywhere else.
+         IL2026 escapes the per-assembly single-warn collapse in ILC, so it must be excluded
+         globally to exempt those same assemblies: the libraries' own code remains guarded
+         against IL2026 by the Roslyn trim analyzers (IsAotCompatible + warnings-as-errors). -->
+    <NoWarn>$(NoWarn);IL2104;IL3053;IL2026</NoWarn>
+  </PropertyGroup>
+
+  <!-- Third-party assemblies with known trim/AOT warnings that cannot be fixed from here.
+       Microsoft.Extensions.Caching.Hybrid: its default reflection-based JSON serializer factory
+       (registered unconditionally by AddHybridCache, required by Duende.AccessTokenManagement)
+       raises IL2026/IL3050/IL2070 even on the latest version; token types are cached through
+       Duende's own serializers at runtime, so the reflection fallback is never exercised. -->
+  <Target Name="ExemptKnownDirtyAssemblies" BeforeTargets="WriteIlcRspFileForCompilation;PrepareForILLink">
+    <ItemGroup>
+      <ManagedAssemblyToLink Condition="'%(Filename)' == 'Microsoft.Extensions.Caching.Hybrid'">
+        <TrimmerSingleWarn>true</TrimmerSingleWarn>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EthernaAuthentication.AspNetCore\EthernaAuthentication.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\EthernaAuthentication.ClientCredentials\EthernaAuthentication.ClientCredentials.csproj" />
+    <ProjectReference Include="..\..\src\EthernaAuthentication.Native\EthernaAuthentication.Native.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="EthernaAuthentication" />
+    <TrimmerRootAssembly Include="EthernaAuthentication.AspNetCore" />
+    <TrimmerRootAssembly Include="EthernaAuthentication.ClientCredentials" />
+    <TrimmerRootAssembly Include="EthernaAuthentication.Native" />
+  </ItemGroup>
+
+</Project>

--- a/test/EthernaAuthentication.AotCompatibility/Program.cs
+++ b/test/EthernaAuthentication.AotCompatibility/Program.cs
@@ -1,0 +1,185 @@
+// Copyright 2021-present Etherna SA
+// This file is part of EthernaAuthentication.
+//
+// EthernaAuthentication is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// EthernaAuthentication is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
+// If not, see <https://www.gnu.org/licenses/>.
+
+namespace Etherna.Authentication.AotCompatibility
+{
+    using Etherna.Authentication;
+    using Etherna.Authentication.AspNetCore;
+    using Etherna.Authentication.ClientCredentials;
+    using Etherna.Authentication.Native;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.Extensions.DependencyInjection;
+    using System;
+    using System.Net.Http;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+
+    // Native AOT compatibility probe for the EthernaAuthentication libraries. The actual compatibility
+    // gate is the ILC publish (see the .csproj and CI): publishing this app fails on any trim/AOT warning.
+    // This entry point additionally proves, at runtime, that the most AOT-sensitive paths work once
+    // compiled ahead-of-time: claim deserialization through the source-generated JSON context, and the
+    // full dependency injection graphs of the three client packages (options, token management, caching),
+    // which rely on infrastructure that is a classic AOT failure area.
+    internal static class Program
+    {
+        // Consts.
+        private const string Authority = "https://sso.example.com";
+
+        // Methods.
+        public static async Task<int> Main()
+        {
+            var failures =
+                await VerifyClaimJsonDeserializationAsync().ConfigureAwait(false) +
+                await VerifyAspNetCoreRegistrationAsync().ConfigureAwait(false) +
+                await VerifyClientCredentialsRegistrationAsync().ConfigureAwait(false) +
+                await VerifyNativeRegistrationAsync().ConfigureAwait(false);
+
+            Console.WriteLine(failures == 0 ? "AOT smoke test PASSED" : $"AOT smoke test FAILED ({failures})");
+            return failures;
+        }
+
+        // Helpers.
+        private static async Task<int> VerifyClaimJsonDeserializationAsync()
+        {
+            // A NotSupportedException here would mean the JsonTypeInfo metadata was missing (the classic AOT failure mode).
+            try
+            {
+                var client = new CannedClaimsClient(
+                    new Claim(EthernaClaimTypes.EtherPreviousAddresses, """["0x0000000000000000000000000000000000000001","0x0000000000000000000000000000000000000002"]"""),
+                    new Claim(EthernaClaimTypes.Role_Dotnet, "probeRole"),
+                    new Claim(EthernaClaimTypes.Username, "probeUser"));
+
+                var prevAddresses = await client.GetEtherPrevAddressesAsync().ConfigureAwait(false);
+                if (prevAddresses.Length != 2)
+                    throw new InvalidOperationException($"Unexpected previous addresses count {prevAddresses.Length}.");
+
+                var roles = await client.GetRolesAsync().ConfigureAwait(false);
+                if (roles.Length != 1 || roles[0] != "probeRole")
+                    throw new InvalidOperationException("Unexpected roles.");
+
+                Console.WriteLine($"[ok] json: deserialized {prevAddresses.Length} previous addresses via source-generated context");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[FAIL] json: {ex.GetType().Name}: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private static async Task<int> VerifyAspNetCoreRegistrationAsync()
+        {
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddAuthentication(EthernaDefaults.AuthenticationScheme)
+                    .AddEthernaOpenIdConnect(options =>
+                    {
+                        options.Authority = Authority;
+                        options.ClientId = "probeClientId";
+                        options.SaveTokens = true;
+                    });
+
+                await using var provider = services.BuildServiceProvider();
+                var scheme = await provider.GetRequiredService<IAuthenticationSchemeProvider>()
+                    .GetSchemeAsync(EthernaDefaults.AuthenticationScheme).ConfigureAwait(false) ??
+                    throw new InvalidOperationException("Etherna authentication scheme not registered.");
+
+                using var scope = provider.CreateScope();
+                _ = scope.ServiceProvider.GetRequiredService<IEthernaOpenIdConnectClient>();
+
+                Console.WriteLine($"[ok] aspnetcore: registered scheme \"{scheme.Name}\" and resolved oidc client");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[FAIL] aspnetcore: {ex.GetType().Name}: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private static async Task<int> VerifyClientCredentialsRegistrationAsync()
+        {
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddEthernaClientCredentials(new Uri(Authority))
+                    .AddClient(
+                        "probeTokenClient",
+                        "probeClientId",
+                        "probeClientSecret",
+                        ["probeScope"],
+                        "probeHttpClient");
+
+                await using var provider = services.BuildServiceProvider();
+
+                // Building the managed client materializes the whole token management handler pipeline.
+                using var httpClient = provider.GetRequiredService<IHttpClientFactory>().CreateClient("probeHttpClient");
+
+                Console.WriteLine("[ok] clientcredentials: resolved managed http client with token management pipeline");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[FAIL] clientcredentials: {ex.GetType().Name}: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private static async Task<int> VerifyNativeRegistrationAsync()
+        {
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddEthernaApiKeyOidcClient(
+                    Authority,
+                    "probeUser.probeKey",
+                    [EthernaScopes.UserApiCredit],
+                    "probeHttpClient");
+
+                await using var provider = services.BuildServiceProvider();
+
+                // Resolving the client builds the sign in service, which pulls the OpenId Connect
+                // options pipeline (post-configuration, data protection, configuration manager).
+                var client = provider.GetRequiredService<IEthernaOpenIdConnectClient>();
+
+                // Unauthenticated user: must return null without touching the network.
+                var clientId = await client.TryGetClientIdAsync().ConfigureAwait(false);
+                if (clientId is not null)
+                    throw new InvalidOperationException("Unexpected client id for unauthenticated user.");
+
+                using var httpClient = provider.GetRequiredService<IHttpClientFactory>().CreateClient("probeHttpClient");
+
+                Console.WriteLine("[ok] native: resolved oidc client and managed http client");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[FAIL] native: {ex.GetType().Name}: {ex.Message}");
+                return 1;
+            }
+        }
+
+        // Test client returning canned user claims, so the probe can drive the claim
+        // deserialization paths without a live SSO server.
+        private sealed class CannedClaimsClient(params Claim[] claims)
+            : EthernaOpenIdConnectClientBase(new DiscoveryDocumentService(Authority))
+        {
+            protected override System.Collections.Generic.IEnumerable<Claim> GetCurrentUserClaims() => claims;
+            protected override Task<string> GetUserAccessTokenAsync() => throw new InvalidOperationException();
+            protected override System.Collections.Generic.IEnumerable<Claim> TryGetCurrentUserClaims() => claims;
+            protected override Task<string?> TryGetUserAccessTokenAsync() => Task.FromResult<string?>(null);
+        }
+    }
+}

--- a/test/EthernaAuthentication.AspNetCore.UnitTest/EthernaOpenIdConnectClientTest.cs
+++ b/test/EthernaAuthentication.AspNetCore.UnitTest/EthernaOpenIdConnectClientTest.cs
@@ -14,7 +14,7 @@
 
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OpenIdConnect;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/EthernaAuthentication.UnitTest/EthernaOpenIdConnectClientBaseTest.cs
+++ b/test/EthernaAuthentication.UnitTest/EthernaOpenIdConnectClientBaseTest.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;


### PR DESCRIPTION
… CI workflow

Add EthernaAuthentication.AotCompatibility probe: publishing it with ILC roots all the libraries and fails on any trim/AOT warning, then CI runs the native binary as a runtime smoke test. The AOT verification blocks both deploy pipelines.

Migrate from the archived IdentityModel packages to their maintained successors with proper trim/AOT annotations: IdentityModel -> Duende.IdentityModel and IdentityModel.OidcClient -> Duende.IdentityModel.OidcClient. Breaking change: IDiscoveryDocumentService now returns Duende.IdentityModel.Client.DiscoveryDocumentResponse.