### PR TITLE
Add regression tests for reading multiple roles from claims

### DIFF
--- a/test/EthernaAuthentication.AotCompatibility/Program.cs
+++ b/test/EthernaAuthentication.AotCompatibility/Program.cs
@@ -57,7 +57,8 @@ namespace Etherna.Authentication.AotCompatibility
             {
                 var client = new CannedClaimsClient(
                     new Claim(EthernaClaimTypes.EtherPreviousAddresses, """["0x0000000000000000000000000000000000000001","0x0000000000000000000000000000000000000002"]"""),
-                    new Claim(EthernaClaimTypes.Role_Dotnet, "probeRole"),
+                    new Claim(EthernaClaimTypes.Role_Dotnet, "probeRole0"),
+                    new Claim(EthernaClaimTypes.Role_Dotnet, "probeRole1"),
                     new Claim(EthernaClaimTypes.Username, "probeUser"));
 
                 var prevAddresses = await client.GetEtherPrevAddressesAsync().ConfigureAwait(false);
@@ -65,7 +66,7 @@ namespace Etherna.Authentication.AotCompatibility
                     throw new InvalidOperationException($"Unexpected previous addresses count {prevAddresses.Length}.");
 
                 var roles = await client.GetRolesAsync().ConfigureAwait(false);
-                if (roles.Length != 1 || roles[0] != "probeRole")
+                if (roles.Length != 2 || roles[0] != "probeRole0" || roles[1] != "probeRole1")
                     throw new InvalidOperationException("Unexpected roles.");
 
                 Console.WriteLine($"[ok] json: deserialized {prevAddresses.Length} previous addresses via source-generated context");

--- a/test/EthernaAuthentication.UnitTest/EthernaOpenIdConnectClientBaseTest.cs
+++ b/test/EthernaAuthentication.UnitTest/EthernaOpenIdConnectClientBaseTest.cs
@@ -138,5 +138,71 @@ namespace Etherna.Authentication
             Assert.False(await client.HasScopesAsync("userApi.credit"));
             Assert.False(discoveryService.UserinfoFallbackEntered);
         }
+
+        [Fact]
+        public async Task GetRolesWithMultipleDotnetRoleClaimsReturnsAllRoles()
+        {
+            var discoveryService = new RecordingDiscoveryDocumentService();
+            var client = new TestOidcClient(discoveryService,
+            [
+                new Claim(EthernaClaimTypes.UserId, "testUserId"),
+                new Claim(EthernaClaimTypes.Role_Dotnet, "testRole0"),
+                new Claim(EthernaClaimTypes.Role_Dotnet, "testRole1")
+            ]);
+
+            var roles = await client.GetRolesAsync();
+
+            Assert.Equal(["testRole0", "testRole1"], roles);
+            Assert.False(discoveryService.UserinfoFallbackEntered);
+        }
+
+        [Fact]
+        public async Task GetRolesWithMultipleIdentityModelRoleClaimsReturnsAllRoles()
+        {
+            var discoveryService = new RecordingDiscoveryDocumentService();
+            var client = new TestOidcClient(discoveryService,
+            [
+                new Claim(EthernaClaimTypes.ClientId, "testClientId"),
+                new Claim(EthernaClaimTypes.Role_IdentityModel, "testRole0"),
+                new Claim(EthernaClaimTypes.Role_IdentityModel, "testRole1")
+            ]);
+
+            var roles = await client.GetRolesAsync();
+
+            Assert.Equal(["testRole0", "testRole1"], roles);
+            Assert.False(discoveryService.UserinfoFallbackEntered);
+        }
+
+        [Fact]
+        public async Task GetRolesWithBothRoleClaimTypesPrefersDotnetClaims()
+        {
+            var discoveryService = new RecordingDiscoveryDocumentService();
+            var client = new TestOidcClient(discoveryService,
+            [
+                new Claim(EthernaClaimTypes.UserId, "testUserId"),
+                new Claim(EthernaClaimTypes.Role_Dotnet, "dotnetRole"),
+                new Claim(EthernaClaimTypes.Role_IdentityModel, "identityModelRole")
+            ]);
+
+            var roles = await client.GetRolesAsync();
+
+            Assert.Equal(["dotnetRole"], roles);
+            Assert.False(discoveryService.UserinfoFallbackEntered);
+        }
+
+        [Fact]
+        public async Task TryGetRolesWithMachinePrincipalWithoutRolesReturnsNullWithoutUserinfoFallback()
+        {
+            var discoveryService = new RecordingDiscoveryDocumentService();
+            var client = new TestOidcClient(discoveryService,
+            [
+                new Claim(EthernaClaimTypes.ClientId, "testClientId")
+            ]);
+
+            var roles = await client.TryGetRolesAsync();
+
+            Assert.Null(roles);
+            Assert.False(discoveryService.UserinfoFallbackEntered);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Resolves [EAUTH-24](https://etherna.atlassian.net/browse/EAUTH-24) — "Permit to read more than one role from claims".

The defect described in the issue (role retrieval reading only a single claim instead of the full collection) was already fixed on `dev` by 16c15b1, which rewrote `GetRolesAsync`/`TryGetRolesAsync` in `EthernaOpenIdConnectClientBase` to collect every matching role claim. What was missing is any test coverage proving the multi-role behavior, so this PR locks it in:

- **`EthernaOpenIdConnectClientBaseTest`**: new tests verifying that `GetRolesAsync` returns all role claims (both `ClaimTypes.Role` and the `role` JWT claim type), that the .NET claim type takes precedence when both are present, and that `TryGetRolesAsync` returns `null` for principals without roles, without triggering the userinfo fallback.
- **AOT probe**: the canned principal now carries two role claims, so the ahead-of-time smoke test exercises the collection path instead of the single-role one.

## Test plan

- `dotnet test` — 30/30 passing across all three unit test projects
- `dotnet run --project test/EthernaAuthentication.AotCompatibility` — smoke test PASSED

[EAUTH-24]: https://etherna.atlassian.net/browse/EAUTH-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ