### PR TITLE
Improve native code return page

### DIFF
--- a/src/EthernaAuthentication.Native/CodeFlow/DefaultReturnPages.cs
+++ b/src/EthernaAuthentication.Native/CodeFlow/DefaultReturnPages.cs
@@ -1,0 +1,143 @@
+// Copyright 2021-present Etherna SA
+// This file is part of EthernaAuthentication.
+//
+// EthernaAuthentication is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// EthernaAuthentication is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with EthernaAuthentication.
+// If not, see <https://www.gnu.org/licenses/>.
+
+namespace Etherna.Authentication.Native.CodeFlow
+{
+    /// <summary>
+    /// Default Etherna-branded pages returned to the browser by <see cref="LoopbackHttpListener"/>
+    /// at the end of the code flow sign-in.
+    /// </summary>
+    /// <remarks>
+    /// Pages are self-contained (inline styles, inline logo, data-uri favicon): the listener lives on the
+    /// loopback address for a few seconds only, so they can't reference any external resource.
+    /// Branding follows the official Etherna brand kit: colored logo on light background,
+    /// white logo on dark background, flat colors only.
+    /// </remarks>
+    internal static class DefaultReturnPages
+    {
+        // Consts.
+        public const string Failure = $$"""
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <meta name="color-scheme" content="light dark">
+                <title>Etherna – Invalid request</title>
+            {{HeadResources}}
+            </head>
+            <body>
+                <main style="border-top-color: #c0504d">
+                    {{LogoSvg}}
+                    <h1>Invalid request</h1>
+                    <p>The sign-in response could not be processed. Please return to the application and try again.</p>
+                </main>
+            </body>
+            </html>
+            """;
+
+        private const string HeadResources = $$"""
+                <link rel="icon" href="data:image/svg+xml;base64,{{LogoSymbolSvgBase64}}">
+                <style>
+                    body {
+                        margin: 0;
+                        min-height: 100vh;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        font-family: Avenir, "Avenir Next", system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+                        background: #eef3f5;
+                        color: #233038;
+                        text-align: center;
+                    }
+                    main {
+                        box-sizing: border-box;
+                        max-width: 26rem;
+                        margin: 1.5rem;
+                        padding: 3rem 2.5rem;
+                        background: #ffffff;
+                        border-top: 0.25rem solid #00aabe;
+                        border-radius: 0.75rem;
+                        box-shadow: 0 0.75rem 2.5rem rgba(35, 48, 56, 0.12);
+                    }
+                    .logo {
+                        width: 12rem;
+                        max-width: 100%;
+                        height: auto;
+                    }
+                    .logo .lettering {
+                        fill: #7797a3;
+                    }
+                    .logo .symbol {
+                        fill: #00abbf;
+                    }
+                    h1 {
+                        margin: 1.75rem 0 0.75rem;
+                        font-size: 1.375rem;
+                        font-weight: 600;
+                    }
+                    p {
+                        margin: 0;
+                        color: #57707c;
+                        line-height: 1.6;
+                    }
+                    @media (prefers-color-scheme: dark) {
+                        body {
+                            background: #11181b;
+                            color: #edf2f4;
+                        }
+                        main {
+                            background: #1c2529;
+                            box-shadow: 0 0.75rem 2.5rem rgba(0, 0, 0, 0.5);
+                        }
+                        .logo .lettering,
+                        .logo .symbol {
+                            fill: #ffffff;
+                        }
+                        p {
+                            color: #9db3bd;
+                        }
+                    }
+                </style>
+            """;
+
+        //official brand kit symbol (logo-symbol.svg), used as favicon
+        private const string LogoSymbolSvgBase64 =
+            "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii02LjAgLTYuMCA3MjIuMiA1MjQuMCI+PHBhdGggZmlsbD0iIzAwQUJCRiIgZD0iTTE2Ni43ODYgNDIyLjcxQzc0LjY2NiA0MjIuNzEgMCAzNDguMDQ2IDAgMjU1LjkxIDAgMTYzLjgzIDc0LjY2NyA4OS4xNjggMTY2Ljc4NiA4OS4xNjhjMzcuMzgzIDAgNzEuOTEgMTIuMjgyIDk5LjcyMyAzMy4wNThoLjA3MVYwYzE4OS42MzMgMCAzNTUuMDM4IDEwMi44ODIgNDQzLjU0IDI1Ni4wMjhDNjIxLjU3NiA0MDkuMDYxIDQ1Ni4xMDUgNTEyIDI2Ni41OCA1MTJWMzg5Ljg2M2MtMjcuODA4IDIwLjc0OC02Mi40MTYgMzIuODQ2LTk5Ljc5NCAzMi44NDZ6TTQ5Ny4xIDI3NS4wNDZjLTEwLjQ1IDUzLjg0OS02Mi41ODUgODkuMDA0LTExNi40MjIgNzguNTRhOTkuMjM1IDk5LjIzNSAwIDAxLTM5LjU1LTE3LjIxbDYyLjI2LTQxLjk5YzQzLjMyLTI5LjIyIDU2LjYwOC04Ni4zMjMgMzEuNTU1LTEzMS4wNyA0NC4zNzUgMTYuODA1IDcxLjUzNCA2My42MDYgNjIuMTU3IDExMS43M3ptLTM2Ni4wNCA3My42MzZjLTI1LjA1Ny00NC43NTItMTEuNzc5LTEwMS44NiAzMS41Ni0xMzEuMDdsNjIuMjYtNDEuOTlhOTkuMjUgOTkuMjUgMCAwMC0zOS41NDUtMTcuMjE1Yy01My44NS0xMC40NjMtMTA1Ljk2NyAyNC42OTEtMTE2LjQzMiA3OC41My05LjM3NiA0OC4xNDkgMTcuNzgyIDk0LjkyNiA2Mi4xNTcgMTExLjc0NXptMTUxLjk0NC0xMzIuNjc2bDQ2LjA1My0zMC42MzJjMTUuMjI4LTEwLjI3IDM1Ljk2OS02LjA3MyA0Ni4yMjYgOS4xMiAxMC4yNTMgMTUuMjA0IDYuMjgxIDM1Ljk2MS04LjkzOCA0Ni4yMzZsLTgzLjM0IDU1LjI3NnY3OS42N2MzMC4wMzYgMjkuMTgyIDcxLjAyOSA0Ny4xNiAxMTYuMjE5IDQ3LjE2IDkyLjEgMCAxNjYuNzgtNzQuNjgyIDE2Ni43OC0xNjYuODA5IDAtOTIuMDgtNzQuNjgtMTY2LjczNy0xNjYuNzgtMTY2LjczNy00NS4xODYgMC04Ni4xODMgMTcuODUtMTE2LjIyIDQ3LjAzNnY3OS42OHptLTE2LjQ5NiA5MC45NDlWMjI3LjA0bC02Ni44NTggNDQuMjNjLTE1LjIxNCAxMC4yOC0xOS4xODEgMzEuMDMyLTguOTE1IDQ2LjIzNSAxMC4yMzQgMTUuMTk4IDMwLjk4NSAxOS4zOTEgNDYuMjA4IDkuMTI2bDI5LjU2Ni0xOS42NzR6Ii8+PC9zdmc+";
+
+        //official brand kit horizontal lockup (logo.svg), fills moved to css for dark scheme support
+        private const string LogoSvg =
+            """<svg class="logo" role="img" aria-label="etherna" viewBox="0 0 2048 512" xmlns="http://www.w3.org/2000/svg"><path class="lettering" d="M839.375 300.136c-6.554-25.266 3.007-53.142 25.906-68.609l39.587-26.707a63.164 63.164 0 00-25.141-10.93c-34.231-6.662-67.373 15.693-74.026 49.934-5.951 30.613 11.303 60.364 39.517 71.053 37.807 9.894 79.892-3.038 96.713-8.772l.306 45.27c-18.899 6.586-56.734 14.039-94.739 8.244-57.308-11.123-94.729-66.616-83.595-123.913 11.139-57.306 66.62-94.727 123.947-83.58 21.184 4.112 39.691 14.317 53.991 28.403v50.918l-102.466 68.69zm553.914 0c-6.55-25.266 3.001-53.142 25.905-68.609l39.588-26.707a63.123 63.123 0 00-25.132-10.93c-34.24-6.662-67.383 15.693-74.04 49.934-5.947 30.613 11.312 60.364 39.526 71.053 37.812 9.894 79.897-3.038 96.718-8.772l.301 45.27c-18.912 6.586-56.734 14.039-94.743 8.244-57.304-11.123-94.73-66.616-83.59-123.913 11.128-57.306 66.623-94.727 123.95-83.58 21.185 4.112 39.688 14.317 53.983 28.403v50.918l-102.466 68.69zm-416.53-144.928v-34.184l49.228-33.106v67.29h54.17v41.835h-54.17v90.728c0 9.85 1.847 17.643 5.545 23.386 3.685 5.752 11.002 8.617 21.948 8.617 4.372 0 9.164-.48 14.366-1.437 5.21-.943 9.296-2.525 12.311-4.711v41.42c-5.215 2.473-11.557 4.179-19.087 5.14-7.515.942-14.144 1.427-19.907 1.427-13.117 0-23.865-1.427-32.2-4.306-8.349-2.86-14.912-7.217-19.7-13.115-4.772-5.885-8.07-13.206-9.838-21.964-1.771-8.74-2.666-18.85-2.666-30.35v-136.67zm181.339 27.055h.82c3.826-8.212 10.592-15.65 20.307-22.36 9.716-6.694 22.225-10.048 37.553-10.048 13.127 0 24.28 2.2 33.444 6.553 9.15 4.39 16.618 10.129 22.366 17.233 5.73 7.114 9.824 15.326 12.302 24.62 2.465 9.305 3.69 19.02 3.69 29.14v127.554h-49.238V252.012c0-5.47-.273-11.548-.815-18.247-.551-6.718-1.988-13.003-4.302-18.882-2.337-5.884-5.955-10.812-10.88-14.77-4.923-3.971-11.628-5.95-20.109-5.95-8.203 0-15.12 1.376-20.713 4.099-5.616 2.742-10.262 6.454-13.95 11.085-3.695 4.65-6.371 9.993-7.997 15.995-1.658 6.025-2.478 12.305-2.478 18.868v110.745h-49.233V120.758l49.233-33.058v94.563zm370.508-27.287h49.233v31.173h.83c5.46-11.48 13.258-20.385 23.379-26.679 10.116-6.275 21.749-9.422 34.871-9.422l.665 46.74s-20.807-1.419-34.5 6.392c-7.105 4.047-12.316 9.083-16.015 14.553-3.694 5.474-6.158 10.944-7.383 16.4-1.23 5.498-1.847 9.582-1.847 12.324V355.53h-49.233V154.976zm131.089 0h46.773v31.588h.815c4.65-9.856 11.751-18.392 21.354-25.652 9.565-7.232 22.545-10.864 38.975-10.864 13.118 0 24.27 2.2 33.435 6.572 9.154 4.362 16.618 10.105 22.347 17.22 5.758 7.118 9.853 15.315 12.321 24.615 2.46 9.31 3.685 19.014 3.685 29.139V355.53h-49.238V252.21c0-5.484-.273-11.562-.805-18.285-.551-6.68-1.998-12.974-4.326-18.863-2.322-5.87-5.936-10.793-10.87-14.756-4.914-3.971-11.614-5.954-20.1-5.954-8.203 0-15.115 1.366-20.731 4.103-5.603 2.737-10.258 6.43-13.933 11.08-3.708 4.655-6.365 9.988-8.005 15.995-1.645 6.012-2.474 12.315-2.474 18.882V355.53h-49.223V154.976zm337.677 110.583h-10.248c-6.841 0-14.507.293-22.993.834-8.476.584-16.472 1.899-23.987 3.99-7.534 2.097-13.89 5.16-19.092 9.211-5.188 4.061-7.798 9.696-7.798 16.941 0 4.763 1.027 8.716 3.081 11.929 2.055 3.213 4.717 5.936 8.001 8.17 3.28 2.232 6.978 3.83 11.082 4.805 4.104.98 8.194 1.47 12.307 1.47 16.958 0 29.472-4.118 37.543-12.363 8.067-8.216 12.104-19.447 12.104-33.675v-11.312zm2.884 62.372h-1.24c-7.119 11.448-16.16 19.735-27.087 24.893-10.94 5.168-22.97 7.745-36.096 7.745a94.384 94.384 0 01-26.466-3.759c-8.623-2.535-16.293-6.275-22.993-11.307-6.686-5.012-12.105-11.302-16.195-18.835-4.108-7.528-6.153-16.334-6.153-26.364 0-10.878 1.903-20.145 5.743-27.824 3.826-7.684 8.953-14.082 15.389-19.26 6.422-5.153 13.88-9.266 22.348-12.333 8.486-3.076 17.301-5.375 26.47-6.916 9.155-1.54 18.39-2.502 27.7-2.944 9.297-.391 18.051-.603 26.254-.603h12.326v-5.456c.551-34.976-45.152-37.647-45.152-37.647s-42.557-7.109-77.749 26.41V172.44c22.532-22.096 105.293-34.02 145.621-5.635 6.568 4.631 11.134 10.807 14.545 17.38 3.435 6.548 5.88 13.177 7.393 19.857 1.493 6.709 2.398 13.196 2.671 19.471.269 6.276.415 11.792.415 16.527v115.494h-47.744v-27.602z"/><path class="symbol" d="M166.786 422.71C74.666 422.71 0 348.046 0 255.91 0 163.83 74.667 89.168 166.786 89.168c37.383 0 71.91 12.282 99.723 33.058h.071V0c189.633 0 355.038 102.882 443.54 256.028C621.576 409.061 456.105 512 266.58 512V389.863c-27.808 20.748-62.416 32.846-99.794 32.846zM497.1 275.046c-10.45 53.849-62.585 89.004-116.422 78.54a99.235 99.235 0 01-39.55-17.21l62.26-41.99c43.32-29.22 56.608-86.323 31.555-131.07 44.375 16.805 71.534 63.606 62.157 111.73zm-366.04 73.636c-25.057-44.752-11.779-101.86 31.56-131.07l62.26-41.99a99.25 99.25 0 00-39.545-17.215c-53.85-10.463-105.967 24.691-116.432 78.53-9.376 48.149 17.782 94.926 62.157 111.745zm151.944-132.676l46.053-30.632c15.228-10.27 35.969-6.073 46.226 9.12 10.253 15.204 6.281 35.961-8.938 46.236l-83.34 55.276v79.67c30.036 29.182 71.029 47.16 116.219 47.16 92.1 0 166.78-74.682 166.78-166.809 0-92.08-74.68-166.737-166.78-166.737-45.186 0-86.183 17.85-116.22 47.036v79.68zm-16.496 90.949V227.04l-66.858 44.23c-15.214 10.28-19.181 31.032-8.915 46.235 10.234 15.198 30.985 19.391 46.208 9.126l29.566-19.674z"/></svg>""";
+
+        public const string Success = $$"""
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <meta name="color-scheme" content="light dark">
+                <title>Etherna – Signed in</title>
+            {{HeadResources}}
+            </head>
+            <body>
+                <main>
+                    {{LogoSvg}}
+                    <h1>You are signed in</h1>
+                    <p>Sign-in completed successfully. You can now close this window and return to the application.</p>
+                </main>
+            </body>
+            </html>
+            """;
+    }
+}

--- a/src/EthernaAuthentication.Native/CodeFlow/LoopbackHttpListener.cs
+++ b/src/EthernaAuthentication.Native/CodeFlow/LoopbackHttpListener.cs
@@ -24,10 +24,10 @@ namespace Etherna.Authentication.Native.CodeFlow
     internal sealed class LoopbackHttpListener : IDisposable
     {
         // Consts.
-        private const string DefaultFailureContentType = "text/html";
-        private const string DefaultFailureResponse = "<h1>Invalid request.</h1>";
-        private const string DefaultSuccessContentType = "text/html";
-        private const string DefaultSuccessResponse = "<h1>You can now return to the application.</h1>";
+        private const string DefaultFailureContentType = "text/html; charset=utf-8";
+        private const string DefaultFailureResponse = DefaultReturnPages.Failure;
+        private const string DefaultSuccessContentType = "text/html; charset=utf-8";
+        private const string DefaultSuccessResponse = DefaultReturnPages.Success;
         private const int DefaultTimeout = 60 * 5; // 5 mins (in seconds)
 
         // Fields.

--- a/test/EthernaAuthentication.Native.UnitTest/CodeFlow/SystemBrowserTest.cs
+++ b/test/EthernaAuthentication.Native.UnitTest/CodeFlow/SystemBrowserTest.cs
@@ -32,6 +32,27 @@ namespace Etherna.Authentication.Native.CodeFlow
 
         // Tests.
         [Fact]
+        public async Task InvokeAsyncReturnsBrandedDefaultSuccessPageToBrowser()
+        {
+            var browser = new SystemBrowser(openBrowser: _ => { });
+
+            var invokeTask = browser.InvokeAsync(
+                new BrowserOptions(StartUrl, $"http://127.0.0.1:{browser.Port}"),
+                CancellationToken.None);
+
+            using var httpClient = new HttpClient();
+            var callbackResponse = await httpClient.GetAsync(new Uri($"http://127.0.0.1:{browser.Port}/?code=xyz"));
+            await invokeTask;
+
+            var content = await callbackResponse.Content.ReadAsStringAsync();
+            Assert.Equal("text/html", callbackResponse.Content.Headers.ContentType?.MediaType);
+            Assert.Equal("utf-8", callbackResponse.Content.Headers.ContentType?.CharSet);
+            Assert.StartsWith("<!DOCTYPE html>", content, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"etherna\"", content, StringComparison.Ordinal);
+            Assert.Contains("You are signed in", content, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public async Task InvokeAsyncReturnsCustomSuccessResponseToBrowser()
         {
             var browser = new SystemBrowser(


### PR DESCRIPTION
Resolves [EAUTH-34](https://etherna.atlassian.net/browse/EAUTH-34).

`LoopbackHttpListener` exposed a very basic page at the end of the native code flow sign-in. This replaces the default success and failure responses with Etherna-branded pages built on the official brand kit:

- horizontal lockup logo (symbol + lettering) with official artwork colors on light background, switching to the white logo on dark color scheme per brand kit rules;
- official digital cyan `#00AABE` as accent (muted red on the failure page);
- pages are fully self-contained (inline styles, inline svg logo, data-uri favicon), since the listener lives on the loopback address for a few seconds only;
- default content type now declares `charset=utf-8`;
- custom responses passed by the caller keep working unchanged.

Preview (light / dark):

| Success (light) | Success (dark) | Failure |
|---|---|---|
| card with colored logo, cyan accent bar, "You are signed in" | dark card with white logo | red accent bar, "Invalid request" |

Added a regression test asserting the branded default page is served to the browser with the expected content type.

[EAUTH-34]: https://etherna.atlassian.net/browse/EAUTH-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ